### PR TITLE
Add docs tab

### DIFF
--- a/src/renderer/components/templates/Docs.vue
+++ b/src/renderer/components/templates/Docs.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="flex" text-center>
+    <div class="main" text-center>
+      <iframe src="https://intuiter.vercel.app/en/usages/text.html" style="width:100%;height:100%;border:none;"></iframe>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+
+export default defineComponent({
+  setup() {
+    return {}
+  }
+})
+</script>
+

--- a/src/renderer/pages/index.vue
+++ b/src/renderer/pages/index.vue
@@ -23,6 +23,10 @@
     <v-tabs-items v-model="index" class="wrapper bottom" id="view" touchless>
       <v-tab-item v-for="(tab, i) in tabs" :key="i" eager class="wrapper">
         <templates-run v-if="tab.key === 'home'" class="wrapper" />
+        <templates-opts v-else-if="tab.key === 'opt'" class="wrapper" />
+        <templates-shortcuts v-else-if="tab.key === 'shortcut'" class="wrapper" />
+        <templates-exts v-else-if="tab.key === 'ext'" class="wrapper" />
+        <templates-docs v-else-if="tab.key === 'docs'" class="wrapper" />
       </v-tab-item>
     </v-tabs-items>
   </v-app>
@@ -42,7 +46,8 @@ export default defineComponent({
       { name: 'Home', key: 'home' },
       { name: 'Option', key: 'opt' },
       { name: 'Shortcut', key: 'shortcut' },
-      { name: 'Extension', key: 'ext' }
+      { name: 'Extension', key: 'ext' },
+      { name: 'Document', key: 'docs' }
     ]
     const index = ref(0)
 


### PR DESCRIPTION
## Summary
- add Documentation tab for the Electron UI
- show Intuiter docs inside a new component with an iframe

## Testing
- `npm run build` *(fails: Electron-nuxt requires yarn)*

------
https://chatgpt.com/codex/tasks/task_e_684478ba17308327a16d2422a94563cb