### PR TITLE
Add custom app hotkey

### DIFF
--- a/resources/ahk/runner.ahk
+++ b/resources/ahk/runner.ahk
@@ -4,6 +4,17 @@ Menu, Tray, Icon, %A_ScriptDir%\img\logo.ico,,1
 ; meta - Administrator
 #SingleInstance Force
 SetWorkingDir %A_ScriptDir%
+; read custom app paths for Win+1..0
+IniRead, CUSTOM_APP_PATH_1, %A_ScriptDir%\..\default.ini, custom, 1, notepad.exe
+IniRead, CUSTOM_APP_PATH_2, %A_ScriptDir%\..\default.ini, custom, 2, notepad.exe
+IniRead, CUSTOM_APP_PATH_3, %A_ScriptDir%\..\default.ini, custom, 3, notepad.exe
+IniRead, CUSTOM_APP_PATH_4, %A_ScriptDir%\..\default.ini, custom, 4, notepad.exe
+IniRead, CUSTOM_APP_PATH_5, %A_ScriptDir%\..\default.ini, custom, 5, notepad.exe
+IniRead, CUSTOM_APP_PATH_6, %A_ScriptDir%\..\default.ini, custom, 6, notepad.exe
+IniRead, CUSTOM_APP_PATH_7, %A_ScriptDir%\..\default.ini, custom, 7, notepad.exe
+IniRead, CUSTOM_APP_PATH_8, %A_ScriptDir%\..\default.ini, custom, 8, notepad.exe
+IniRead, CUSTOM_APP_PATH_9, %A_ScriptDir%\..\default.ini, custom, 9, notepad.exe
+IniRead, CUSTOM_APP_PATH_0, %A_ScriptDir%\..\default.ini, custom, 0, notepad.exe
 
 if not A_IsAdmin
     Run *RunAs "%A_ScriptFullPath%",,hide

--- a/resources/ahk/runner.ahk
+++ b/resources/ahk/runner.ahk
@@ -5,17 +5,19 @@ Menu, Tray, Icon, %A_ScriptDir%\img\logo.ico,,1
 #SingleInstance Force
 SetWorkingDir %A_ScriptDir%
 ; read custom app paths for Win+1..0
-IniRead, CUSTOM_APP_PATH_1, %A_ScriptDir%\..\default.ini, custom, 1, notepad.exe
-IniRead, CUSTOM_APP_PATH_2, %A_ScriptDir%\..\default.ini, custom, 2, notepad.exe
-IniRead, CUSTOM_APP_PATH_3, %A_ScriptDir%\..\default.ini, custom, 3, notepad.exe
-IniRead, CUSTOM_APP_PATH_4, %A_ScriptDir%\..\default.ini, custom, 4, notepad.exe
-IniRead, CUSTOM_APP_PATH_5, %A_ScriptDir%\..\default.ini, custom, 5, notepad.exe
-IniRead, CUSTOM_APP_PATH_6, %A_ScriptDir%\..\default.ini, custom, 6, notepad.exe
-IniRead, CUSTOM_APP_PATH_7, %A_ScriptDir%\..\default.ini, custom, 7, notepad.exe
-IniRead, CUSTOM_APP_PATH_8, %A_ScriptDir%\..\default.ini, custom, 8, notepad.exe
-IniRead, CUSTOM_APP_PATH_9, %A_ScriptDir%\..\default.ini, custom, 9, notepad.exe
-IniRead, CUSTOM_APP_PATH_0, %A_ScriptDir%\..\default.ini, custom, 0, notepad.exe
+; Read all custom app paths from the INI file
+IniRead, CustomAppPaths, %A_ScriptDir%\..\default.ini, custom
 
+; Assign each custom app path to its corresponding variable
+Loop, 10
+{
+    Key := Mod(A_Index, 10)  ; Keys are 1-9, 0
+    Default := "notepad.exe"
+    Value := StrSplit(CustomAppPaths, "`n")[Key]
+    Value := (Value != "") ? Value : Default
+    VarName := "CUSTOM_APP_PATH_" . Key
+    %VarName% := Value
+}
 if not A_IsAdmin
     Run *RunAs "%A_ScriptFullPath%",,hide
 

--- a/resources/ahk/src/win/app_shortcut.ahk
+++ b/resources/ahk/src/win/app_shortcut.ahk
@@ -20,51 +20,22 @@ Lwin & t::
 return
 
 ; meta - custom application hotkeys for Win+1..0
-Lwin & 1::
-    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
-        Run %CUSTOM_APP_PATH_1%,,hide
-    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
-        Run *Runas %CUSTOM_APP_PATH_1%,,hide
-    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
-        send #1
-return
+Loop, 10
+{
+    num := A_Index
+    if (num = 10)
+        num := 0
+    Hotkey, % "Lwin & " num "::", Func("HandleHotkey").Bind(num)
+}
 
-Lwin & 2::
+HandleHotkey(num) {
     if (!GetKeyState("shift") && !GetKeyState("ctrl"))
-        Run %CUSTOM_APP_PATH_2%,,hide
+        Run % CUSTOM_APP_PATH_%num%,,hide
     else if (!GetKeyState("shift") && GetKeyState("ctrl"))
-        Run *Runas %CUSTOM_APP_PATH_2%,,hide
+        Run *Runas % CUSTOM_APP_PATH_%num%,,hide
     else if (GetKeyState("shift") && !GetKeyState("ctrl"))
-        send #2
-return
-
-Lwin & 3::
-    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
-        Run %CUSTOM_APP_PATH_3%,,hide
-    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
-        Run *Runas %CUSTOM_APP_PATH_3%,,hide
-    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
-        send #3
-return
-
-Lwin & 4::
-    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
-        Run %CUSTOM_APP_PATH_4%,,hide
-    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
-        Run *Runas %CUSTOM_APP_PATH_4%,,hide
-    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
-        send #4
-return
-
-Lwin & 5::
-    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
-        Run %CUSTOM_APP_PATH_5%,,hide
-    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
-        Run *Runas %CUSTOM_APP_PATH_5%,,hide
-    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
-        send #5
-return
-
+        send #%num%
+}
 Lwin & 6::
     if (!GetKeyState("shift") && !GetKeyState("ctrl"))
         Run %CUSTOM_APP_PATH_6%,,hide

--- a/resources/ahk/src/win/app_shortcut.ahk
+++ b/resources/ahk/src/win/app_shortcut.ahk
@@ -18,3 +18,94 @@ Lwin & t::
     else if (GetKeyState("shift") && !GetKeyState("ctrl"))
         send #t
 return
+
+; meta - custom application hotkeys for Win+1..0
+Lwin & 1::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_1%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_1%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #1
+return
+
+Lwin & 2::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_2%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_2%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #2
+return
+
+Lwin & 3::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_3%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_3%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #3
+return
+
+Lwin & 4::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_4%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_4%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #4
+return
+
+Lwin & 5::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_5%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_5%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #5
+return
+
+Lwin & 6::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_6%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_6%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #6
+return
+
+Lwin & 7::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_7%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_7%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #7
+return
+
+Lwin & 8::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_8%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_8%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #8
+return
+
+Lwin & 9::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_9%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_9%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #9
+return
+
+Lwin & 0::
+    if (!GetKeyState("shift") && !GetKeyState("ctrl"))
+        Run %CUSTOM_APP_PATH_0%,,hide
+    else if (!GetKeyState("shift") && GetKeyState("ctrl"))
+        Run *Runas %CUSTOM_APP_PATH_0%,,hide
+    else if (GetKeyState("shift") && !GetKeyState("ctrl"))
+        send #0
+return

--- a/resources/default.ini
+++ b/resources/default.ini
@@ -1,0 +1,11 @@
+[custom]
+1=notepad.exe
+2=notepad.exe
+3=notepad.exe
+4=notepad.exe
+5=notepad.exe
+6=notepad.exe
+7=notepad.exe
+8=notepad.exe
+9=notepad.exe
+0=notepad.exe

--- a/src/renderer/components/templates/Custom.vue
+++ b/src/renderer/components/templates/Custom.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="flex" text-center>
+    <div class="main" text-center>
+      <div v-for="(d, i) in digits" :key="d" class="mb-2">
+        <v-text-field v-model="paths[i]" :label="`Win+${d}`" />
+      </div>
+      <v-btn color="primary" @click="save">Save</v-btn>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref } from '@vue/composition-api'
+import { remote } from 'electron'
+import { resolve } from 'path'
+import { promises } from 'fs'
+import { useStore } from '@nuxtjs/composition-api'
+import ini from 'ini'
+import type { Store } from 'vuex'
+import type { State } from '~/store/'
+
+const INI_PATH = 'resources\\default.ini'
+
+export default defineComponent({
+  setup(_, ctx) {
+    const store: Store<State> = useStore()
+    const digits = ['1','2','3','4','5','6','7','8','9','0']
+    const paths = ref<string[]>(Array(10).fill(''))
+
+    onMounted(async () => {
+      const root = resolve(remote.app.getAppPath(), '../../')
+      const file = resolve(root, INI_PATH)
+      try {
+        const text = await promises.readFile(file, 'utf8')
+        const conf = ini.parse(text)
+        const section = conf.custom || {}
+        digits.forEach((d, i) => {
+          if (section[d]) {
+            paths.value[i] = section[d]
+            store.commit('setCustomAppPath', { index: i, value: section[d] })
+          }
+        })
+      } catch {}
+    })
+
+    async function save() {
+      digits.forEach((d, i) => {
+        store.commit('setCustomAppPath', { index: i, value: paths.value[i] })
+      })
+      const root = resolve(remote.app.getAppPath(), '../../')
+      const file = resolve(root, INI_PATH)
+      const content = ini.stringify({ custom: digits.reduce((o, d, i) => { o[d] = paths.value[i]; return o }, {} ) })
+      await promises.writeFile(file, content)
+      ctx.root.$toast.success('Saved')
+    }
+
+    return { digits, paths, save }
+  }
+})
+</script>

--- a/src/renderer/components/templates/Custom.vue
+++ b/src/renderer/components/templates/Custom.vue
@@ -40,7 +40,9 @@ export default defineComponent({
             store.commit('setCustomAppPath', { index: i, value: section[d] })
           }
         })
-      } catch {}
+      } catch (error) {
+        console.error('Failed to read or parse the INI file:', error)
+      }
     })
 
     async function save() {

--- a/src/renderer/pages/index.vue
+++ b/src/renderer/pages/index.vue
@@ -23,6 +23,10 @@
     <v-tabs-items v-model="index" class="wrapper bottom" id="view" touchless>
       <v-tab-item v-for="(tab, i) in tabs" :key="i" eager class="wrapper">
         <templates-run v-if="tab.key === 'home'" class="wrapper" />
+        <templates-opts v-else-if="tab.key === 'opt'" class="wrapper" />
+        <templates-shortcuts v-else-if="tab.key === 'shortcut'" class="wrapper" />
+        <templates-exts v-else-if="tab.key === 'ext'" class="wrapper" />
+        <templates-custom v-else-if="tab.key === 'custom'" class="wrapper" />
       </v-tab-item>
     </v-tabs-items>
   </v-app>
@@ -42,7 +46,8 @@ export default defineComponent({
       { name: 'Home', key: 'home' },
       { name: 'Option', key: 'opt' },
       { name: 'Shortcut', key: 'shortcut' },
-      { name: 'Extension', key: 'ext' }
+      { name: 'Extension', key: 'ext' },
+      { name: 'Custom', key: 'custom' }
     ]
     const index = ref(0)
 

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1,11 +1,13 @@
 export type State = {
   loading: boolean
+  customAppPaths: string[]
 }
 
 export const strict = false
 
 export const state = (): State => ({
-  loading: false
+  loading: false,
+  customAppPaths: Array(10).fill('')
 })
 
 export const mutations = {
@@ -14,5 +16,9 @@ export const mutations = {
      * @summary - set global loading state
      */
     state.loading = value
+  }
+  ,
+  setCustomAppPath(state: State, payload: { index: number; value: string }): void {
+    state.customAppPaths[payload.index] = payload.value
   }
 }


### PR DESCRIPTION
## Summary
- allow user customizable application paths for Win+1..0 in `default.ini`
- load all custom paths in the AHK runner
- bind each hotkey in `app_shortcut.ahk`
- add UI fields for every shortcut in Custom tab
- store and update paths array in Vuex

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684478f443f48327bf293ec64d3a747c