### PR TITLE
Add CapsLock toggle for shortcuts

### DIFF
--- a/resources/ahk/src/win/global_win.ahk
+++ b/resources/ahk/src/win/global_win.ahk
@@ -111,3 +111,18 @@ Lalt & m::
     else if (GetKeyState("Lwin")){
     }
 return
+
+; meta - toggle all dynamic shortcuts with alt + CapsLock
+Lalt & CapsLock::
+    Suspend, Permit
+    Suspend, Toggle
+    if (A_IsSuspended)
+        ToolTip, Intuiter Shortcuts Off
+    else
+        ToolTip, Intuiter Shortcuts On
+    SetTimer, RemoveToolTip, -1000
+return
+
+RemoveToolTip:
+    ToolTip
+return

--- a/resources/ahk/src/win/global_win.ahk
+++ b/resources/ahk/src/win/global_win.ahk
@@ -120,7 +120,7 @@ Lalt & CapsLock::
         ToolTip, Intuiter Shortcuts Off
     else
         ToolTip, Intuiter Shortcuts On
-    SetTimer, RemoveToolTip, -1000
+    SetTimer, RemoveToolTip, %TOOLTIP_DISPLAY_DURATION%
 return
 
 RemoveToolTip:


### PR DESCRIPTION
## Summary
- add an Alt+CapsLock hotkey in AHK scripts to suspend and resume dynamic shortcuts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684479da47c8832799638db54d07ad5c