### PR TITLE
Add electron auto update functionality

### DIFF
--- a/builder.config.js
+++ b/builder.config.js
@@ -19,6 +19,7 @@ module.exports = {
   productName: 'Intuiter',
   appId: 'com.seonglae.intuiter',
   artifactName: 'Intuiter-${version}.${ext}',
+  publish: [{ provider: 'github' }],
   directories: { output: 'build' },
   extraResources: [{ from: './resources/ahk/', to: 'ahk' }],
   files: ['package.json', { from: 'dist/main/', to: 'dist/main/' }, { from: 'dist/renderer', to: 'dist/renderer/' }],

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -5,3 +5,4 @@ app.on('window-all-closed', function() {
 })
 
 require('./mainWindow')
+require('./updater')

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -1,0 +1,19 @@
+import { app, dialog, autoUpdater } from 'electron'
+
+const server = 'https://update.electronjs.org'
+const feed = `${server}/seonglae/intuiter/${process.platform}-${process.arch}/${app.getVersion()}`
+autoUpdater.setFeedURL({ url: feed })
+
+app.whenReady().then(() => {
+  autoUpdater.checkForUpdates()
+})
+
+autoUpdater.on('update-downloaded', () => {
+  const result = dialog.showMessageBoxSync({
+    type: 'question',
+    buttons: ['Restart', 'Later'],
+    defaultId: 0,
+    message: 'A new update is ready. Restart to install now?'
+  })
+  if (result === 0) autoUpdater.quitAndInstall()
+})


### PR DESCRIPTION
## Summary
- configure builder to publish release metadata to GitHub
- implement an `updater` module to check for new versions
- load the updater in the main process

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844c6372138832788474b01fdea2695